### PR TITLE
feat: honour port overrides

### DIFF
--- a/api/src/main.ts
+++ b/api/src/main.ts
@@ -1,8 +1,10 @@
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
 
+const port = process.env.PORT || 3000
+
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
-  await app.listen(3000);
+  await app.listen(port);
 }
 bootstrap();


### PR DESCRIPTION
Honour `PORT` environment variable when passed into the application from docker-compose